### PR TITLE
properly reset filter when launching a new search

### DIFF
--- a/rao-front/src/components/Home.vue
+++ b/rao-front/src/components/Home.vue
@@ -90,6 +90,7 @@ export default {
       this.page = 0
       this.searching = search
       this.activeFilters = {}
+      this.stringFilters = ''
       this.search(search)
       this.start = true
     },


### PR DESCRIPTION
Filters were still active even after launching a new search, while there was no visual feedback of any kind for any active filter.