### PR TITLE
Replace "region" by "agence" in document overview

### DIFF
--- a/rao-front/src/components/Document.vue
+++ b/rao-front/src/components/Document.vue
@@ -9,7 +9,7 @@
       </div>
       <div class="informations">
         Client : <strong>{{item.Client}}</strong><br>
-        Région : <strong>{{item.Region}}</strong><br>
+        Agence : <strong>{{item.Agence}}</strong><br>
       </div>
       <v-contents :content="item._snippetResult.Content.value" :search="search"></v-contents>
     </div>


### PR DESCRIPTION
We don't need the region data, and it isn't exposed by back-office. Agency makes more sense.