### PR TITLE
fixed double authentication

### DIFF
--- a/rao-front/src/router/index.js
+++ b/rao-front/src/router/index.js
@@ -44,7 +44,7 @@ const router = new Router({
 })
 
 router.beforeEach((to, from, next) => {
-  if (to.name === 'login' || isConnected()) {
+  if (to.name === 'login' || isConnected() || to.path.substr(0, 14) === '/access_token=') {
     return next()
   }
   next('/login')


### PR DESCRIPTION
The beforeEach guard used to redirect the user to /login before the token was stored in localStorage. It now checks if the path of the next route begins with "/access_token=" which means the authentication is being processed by auth0