### PR TITLE
chore: restore docd in dev mode

### DIFF
--- a/rao-back/docker-compose.yml
+++ b/rao-back/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   docd:
-    build: ./_docd
+    build: ../docd
     networks:
       - intra
   dev:


### PR DESCRIPTION
When we moved to appengine, we moved the docd folder without updating the docker-compose.yml file accordingly.

This makes the build entry in the docker-compose.yml file point to the actual directory where the Dockerfile sits.

